### PR TITLE
Add new features solving the third issue: decompress gziped payload + use aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,14 @@ dev:
 build:
 	wails build -tags webkit2_41
 
+build linux:
+	wails build -tags webkit2_41 -platform linux/amd64
+
+build windows:
+	wails build -tags webkit2_41 -platform windows/amd64
+
+build mac:
+	wails build -tags webkit2_41 -platform darwin/universal
+
 sim:
 	cd simulator && npm start

--- a/backend/core/app.go
+++ b/backend/core/app.go
@@ -22,13 +22,14 @@ import (
 
 // App struct
 type App struct {
-	context     context.Context
-	MQTTCLIENT  MQTT.Client
-	QUEUE       chan MQTTMessage
-	DROPCOUNT   int64
-	RAWMESSAGES chan MQTT.Message
-	stop        context.CancelFunc
-	lastTopic   string
+	context       context.Context
+	MQTTCLIENT    MQTT.Client
+	QUEUE         chan MQTTMessage
+	DROPCOUNT     int64
+	RAWMESSAGES   chan MQTT.Message
+	stop          context.CancelFunc
+	lastTopic     string
+	aliasRegistry map[string]map[uint64]string
 }
 
 // NewApp creates a new App application struct
@@ -60,26 +61,58 @@ func (a *App) init() {
 	a.RAWMESSAGES = make(chan MQTT.Message, 1000)
 	a.DROPCOUNT = 0
 	a.lastTopic = ""
+	a.aliasRegistry = make(map[string]map[uint64]string)
+}
+
+func (a *App) newPayload(payload []byte) (string, int64) {
+	return string(payload), time.Now().Unix()
 }
 
 func (a *App) decode(topic string, payload []byte) (string, int64) {
-	p := sparkplug.Payload{}
-	err := p.DecodePayload(payload)
 
-	// Use the Sparkplug result when:
-	//   • the topic is a known Sparkplug namespace (always trust it), OR
-	//   • parsing succeeded AND the payload looks like real Sparkplug data
-	//     (proto.Unmarshal is permissive — it can silently "succeed" on plain text).
-	if err == nil && (p.IsSparkplugTopic(topic) || p.LooksValid()) {
-		pjson, _ := json.Marshal(p.Metrics)
-		ts := p.Timestamp.Unix()
-		if p.Timestamp.IsZero() {
-			ts = time.Now().Unix()
-		}
-		return string(pjson), ts
+	p := sparkplug.Payload{}
+
+	// not Sparkplug
+	if !p.IsSparkplugTopic(topic) {
+		return a.newPayload(payload)
 	}
 
-	return string(payload), time.Now().Unix()
+	group, msgType, nodeID, deviceID := sparkplug.ParseSparkplugTopic(topic)
+
+	// Build the registry key scoped to the edge node (NBIRTH/NDATA) or device (DBIRTH/DDATA).
+	var registryKey string
+	if group != "" {
+		registryKey = group + "/" + nodeID
+		if deviceID != "" {
+			registryKey += "/" + deviceID
+		}
+	}
+
+	payload = sparkplug.TryDecompress(payload)
+
+	// For data messages, pass the cached alias map so alias-only metrics resolve to names.
+	var aliasLookup map[uint64]string
+	if (msgType == "NDATA" || msgType == "DDATA") && registryKey != "" {
+		aliasLookup = a.aliasRegistry[registryKey]
+	}
+
+	if err := p.DecodePayload(payload, aliasLookup); err != nil || !p.LooksValid() {
+		return a.newPayload(payload)
+	}
+
+	// Populate the alias registry from birth messages so subsequent data messages resolve cleanly.
+	if (msgType == "NBIRTH" || msgType == "DBIRTH") && registryKey != "" {
+		if aliases := p.ExtractAliases(); len(aliases) > 0 {
+			a.aliasRegistry[registryKey] = aliases
+		}
+	}
+
+	pjson, _ := json.Marshal(p.Metrics)
+	ts := p.Timestamp.Unix()
+	if p.Timestamp.IsZero() {
+		ts = time.Now().Unix()
+	}
+	return string(pjson), ts
 }
 
 func (a *App) pushMessage(topic string, payload string, timestamp int64) {

--- a/backend/core/app.go
+++ b/backend/core/app.go
@@ -69,13 +69,11 @@ func (a *App) newPayload(payload []byte) (string, int64) {
 }
 
 func (a *App) decode(topic string, payload []byte) (string, int64) {
-
-	p := sparkplug.Payload{}
-
-	// not Sparkplug
-	if !p.IsSparkplugTopic(topic) {
+	if !sparkplug.IsSparkplugTopic(topic) {
 		return a.newPayload(payload)
 	}
+
+	var p sparkplug.Payload
 
 	group, msgType, nodeID, deviceID := sparkplug.ParseSparkplugTopic(topic)
 

--- a/backend/sparkplug/methods.go
+++ b/backend/sparkplug/methods.go
@@ -35,8 +35,9 @@ func TryDecompress(data []byte) []byte {
 	// GZIP: magic 0x1f 0x8b
 	if data[0] == 0x1f && data[1] == 0x8b {
 		if r, err := gzip.NewReader(bytes.NewReader(data)); err == nil {
-			defer r.Close()
-			if out, err := io.ReadAll(r); err == nil {
+			out, err := io.ReadAll(r)
+			r.Close()
+			if err == nil {
 				return out
 			}
 		}
@@ -44,8 +45,9 @@ func TryDecompress(data []byte) []byte {
 	// zlib (DEFLATE with wrapper): first byte 0x78
 	if data[0] == 0x78 {
 		if r, err := zlib.NewReader(bytes.NewReader(data)); err == nil {
-			defer r.Close()
-			if out, err := io.ReadAll(r); err == nil {
+			out, err := io.ReadAll(r)
+			r.Close()
+			if err == nil {
 				return out
 			}
 		}
@@ -231,8 +233,8 @@ func (p *Payload) LooksValid() bool {
 	return !p.Timestamp.IsZero() || len(p.Metrics) > 0
 }
 
-// isSparkplugTopic returns true for topics that follow the spBv1.0 / spAv1.0 namespace.
-func (p *Payload) IsSparkplugTopic(topic string) bool {
+// IsSparkplugTopic returns true for topics that follow the spBv1.0 / spAv1.0 namespace.
+func IsSparkplugTopic(topic string) bool {
 	return strings.HasPrefix(topic, "spBv1.0/") || strings.HasPrefix(topic, "spAv1.0/")
 }
 

--- a/backend/sparkplug/methods.go
+++ b/backend/sparkplug/methods.go
@@ -11,7 +11,11 @@
 package sparkplug
 
 import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
 	"fmt"
+	"io"
 	"sparkplugui/backend/sparkplug/sproto"
 	"strings"
 	"time"
@@ -22,8 +26,53 @@ import (
 // see the JavaScipt version to be inspired:
 // https://github.com/eclipse/tahu/blob/master/javascript/core/sparkplug-payload/lib/sparkplugbpayload.ts
 
+// tryDecompress attempts GZIP then zlib (DEFLATE) decompression using magic-byte detection.
+// Returns the original bytes unchanged if neither format is detected or decompression fails.
+func TryDecompress(data []byte) []byte {
+	if len(data) < 2 {
+		return data
+	}
+	// GZIP: magic 0x1f 0x8b
+	if data[0] == 0x1f && data[1] == 0x8b {
+		if r, err := gzip.NewReader(bytes.NewReader(data)); err == nil {
+			defer r.Close()
+			if out, err := io.ReadAll(r); err == nil {
+				return out
+			}
+		}
+	}
+	// zlib (DEFLATE with wrapper): first byte 0x78
+	if data[0] == 0x78 {
+		if r, err := zlib.NewReader(bytes.NewReader(data)); err == nil {
+			defer r.Close()
+			if out, err := io.ReadAll(r); err == nil {
+				return out
+			}
+		}
+	}
+	return data
+}
+
+// ParseSparkplugTopic splits a Sparkplug B/A topic into its components.
+// Topic format: spBv1.0/{group}/{messageType}/{nodeID}[/{deviceID}]
+// Returns empty strings for all fields if the topic is not a Sparkplug topic.
+func ParseSparkplugTopic(topic string) (group, messageType, nodeID, deviceID string) {
+	parts := strings.SplitN(topic[8:], "/", 4)
+	if len(parts) < 3 {
+		return
+	}
+	group = parts[0]
+	messageType = parts[1]
+	nodeID = parts[2]
+	if len(parts) == 4 {
+		deviceID = parts[3]
+	}
+	return
+}
+
 type Metric struct {
 	Name     string
+	Alias    uint64 `json:",omitempty"`
 	DataType string
 	Value    any
 }
@@ -90,7 +139,10 @@ type Payload struct {
 //	return proto.Marshal(&sp)
 //}
 
-func (p *Payload) DecodePayload(data []byte) error {
+// DecodePayload decodes a (possibly compressed) Sparkplug protobuf payload.
+// aliasLookup, when non-nil, is used to resolve alias-only metrics (NDATA/DDATA) back
+// to their original metric names registered from a prior birth message.
+func (p *Payload) DecodePayload(data []byte, aliasLookup map[uint64]string) error {
 	pl := sproto.Payload{}
 	if err := proto.Unmarshal(data, &pl); err != nil {
 		return err
@@ -104,11 +156,23 @@ func (p *Payload) DecodePayload(data []byte) error {
 	p.Metrics = make([]Metric, len(pl.Metrics))
 
 	for i, m := range pl.Metrics {
+		if m.Alias != nil {
+			p.Metrics[i].Alias = *m.Alias
+		}
+
 		// Name is optional in NDATA/DDATA — metrics may be alias-only.
 		if m.Name != nil {
 			p.Metrics[i].Name = *m.Name
 		} else if m.Alias != nil {
-			p.Metrics[i].Name = fmt.Sprintf("alias:%d", *m.Alias)
+			if aliasLookup != nil {
+				if name, ok := aliasLookup[*m.Alias]; ok {
+					p.Metrics[i].Name = name
+				} else {
+					p.Metrics[i].Name = fmt.Sprintf("alias:%d", *m.Alias)
+				}
+			} else {
+				p.Metrics[i].Name = fmt.Sprintf("alias:%d", *m.Alias)
+			}
 		}
 
 		// Datatype is optional; skip value extraction if absent.
@@ -170,4 +234,16 @@ func (p *Payload) LooksValid() bool {
 // isSparkplugTopic returns true for topics that follow the spBv1.0 / spAv1.0 namespace.
 func (p *Payload) IsSparkplugTopic(topic string) bool {
 	return strings.HasPrefix(topic, "spBv1.0/") || strings.HasPrefix(topic, "spAv1.0/")
+}
+
+// ExtractAliases returns a map of alias → metric name for all metrics that carry both.
+// Call this after decoding a birth message (NBIRTH / DBIRTH) to populate the alias registry.
+func (p *Payload) ExtractAliases() map[uint64]string {
+	result := make(map[uint64]string)
+	for _, m := range p.Metrics {
+		if m.Alias != 0 && m.Name != "" && !strings.HasPrefix(m.Name, "alias:") {
+			result[m.Alias] = m.Name
+		}
+	}
+	return result
 }

--- a/frontend/src/components/events/ConnectButton.tsx
+++ b/frontend/src/components/events/ConnectButton.tsx
@@ -35,7 +35,7 @@ export const ConnectButton: React.FC = () => {
 
     const information = useSelector(getMQTTSetup);
     const connected = useSelector(getConnected);
-    const lastTopicRef = useRef<string>('');
+    const lastConnectionRef = useRef<string>('');
     const [connecting, setConnecting] = useState(false);
 
     const showError = (errorCode: string) => {
@@ -63,10 +63,11 @@ export const ConnectButton: React.FC = () => {
                     toast.success(`${t('successConnect')}`);
                     dispatch(setConnected(true));
                     dispatch(clearMessages());
-                    if (information.topic !== lastTopicRef.current) {
+                    const connectionKey = `${information.host}:${information.port ?? ''}/${information.topic}`;
+                    if (connectionKey !== lastConnectionRef.current) {
                         dispatch(clearLastMessages());
                         dispatch(incrementTreeReset());
-                        lastTopicRef.current = information.topic;
+                        lastConnectionRef.current = connectionKey;
                     }
                     dispatch(setMQTTFilenames(initMQTTFilenamesSlice));
                     dispatch(setMQTTSetup({...information, cacrt: '', clientcrt: '', clientkey: ''}));

--- a/frontend/src/components/events/OpenNodesButton.tsx
+++ b/frontend/src/components/events/OpenNodesButton.tsx
@@ -17,6 +17,7 @@ import VerticalAlignCenterOutlinedIcon from "@mui/icons-material/VerticalAlignCe
 import {AmbreIconButton} from "../ambre/AmbreIconButton.tsx";
 import {getParentNodes} from "../../redux/data/parentNodesSlice.ts";
 import {getOpenedNodes, initOpenedNodes, setOpenedNodes} from "../../redux/data/openedNodesSlice.ts";
+import {getConnected} from "../../redux/events/connectedSlice.ts";
 
 
 export const OpenNodesButton: React.FC = () => {
@@ -25,13 +26,14 @@ export const OpenNodesButton: React.FC = () => {
 
     const parents = useSelector(getParentNodes);
     const openedNodes = useSelector(getOpenedNodes);
+    const connected = useSelector(getConnected);
     const closed = openedNodes.length === initOpenedNodes.length;
 
     const goClick = () => dispatch(setOpenedNodes(closed ? parents : initOpenedNodes));
 
     return closed ? (
-        <AmbreIconButton onClick={goClick} icon={<ExpandOutlinedIcon/>} tooltipTitle={t('open')}/>
+        <AmbreIconButton onClick={goClick} icon={<ExpandOutlinedIcon/>} tooltipTitle={t('open')} disabled={connected}/>
     ) : (
-        <AmbreIconButton onClick={goClick} icon={<VerticalAlignCenterOutlinedIcon/>} tooltipTitle={t('close')}/>
+        <AmbreIconButton onClick={goClick} icon={<VerticalAlignCenterOutlinedIcon/>} tooltipTitle={t('close')} disabled={connected}/>
     );
 };

--- a/frontend/src/components/tree/Tree.tsx
+++ b/frontend/src/components/tree/Tree.tsx
@@ -13,7 +13,7 @@ import DisabledByDefaultOutlinedIcon from "@mui/icons-material/DisabledByDefault
 import {Grid} from "@mui/material";
 import IndeterminateCheckBoxOutlinedIcon from "@mui/icons-material/IndeterminateCheckBoxOutlined";
 import {TreeView} from "@mui/x-tree-view";
-import {useDispatch, useSelector} from "react-redux";
+import {useDispatch, useSelector, useStore} from "react-redux";
 import {useTranslation} from "react-i18next";
 
 import {constants} from "../../utils/constants.ts";
@@ -21,7 +21,7 @@ import {getTreeReset} from "../../redux/events/treeResetSlice.ts";
 import {getOpenedNodes, setOpenedNodes} from "../../redux/data/openedNodesSlice.ts";
 import {getMessages} from "../../redux/data/messagesSlice.ts";
 import {initParentNodes, setParentNodes} from "../../redux/data/parentNodesSlice.ts";
-import {MessagesType, NodeType} from "../../utils/types.ts";
+import {NodeType} from "../../utils/types.ts";
 import {setLastMessages} from "../../redux/data/lastMessagesSlice.ts";
 import {styles} from "../../styles/styles.ts";
 import {TreeItemRender} from "./TreeItemRender.tsx";
@@ -33,67 +33,89 @@ import {core} from "../../../wailsjs/go/models.ts";
 export const Tree: React.FC = () => {
     const {t} = useTranslation();
     const dispatch = useDispatch();
+    const store = useStore();
 
     const treeReset = useSelector(getTreeReset);
-    const messages: MessagesType = useSelector(getMessages);
-
     const openedNodes = useSelector(getOpenedNodes);
 
     const treeRef = useRef<NodeType>(utils.createNode(constants.rootID, t('root'), [], {nodeID: ''}));
-    const accParentsRef = useRef<string[]>([...initParentNodes]);
+    // Flat map nodeID → node for O(1) lookup instead of O(n) find() per segment
+    const nodeMapRef = useRef<Map<string, NodeType>>(new Map([[constants.rootID, treeRef.current]]));
+    // Set of known leaf topics: skips tree-walking entirely for already-seen topics
+    const knownLeafsRef = useRef<Set<string>>(new Set());
+    // Set instead of array: no duplicates, no unbounded growth
+    const accParentsRef = useRef<Set<string>>(new Set(initParentNodes));
     const processedRef = useRef(0);
     const [tree, setTree] = useState<NodeType>(treeRef.current);
 
-    // Reset tree only when topic changes (treeReset counter increments)
+    // Reset tree when topic/host changes
     useEffect(() => {
         if (treeReset === 0) return;
         treeRef.current = utils.createNode(constants.rootID, t('root'), [], {nodeID: ''});
-        accParentsRef.current = [...initParentNodes];
+        nodeMapRef.current = new Map([[constants.rootID, treeRef.current]]);
+        knownLeafsRef.current = new Set();
+        accParentsRef.current = new Set(initParentNodes);
         processedRef.current = 0;
         setTree(treeRef.current);
         dispatch(setParentNodes([...initParentNodes]));
     }, [treeReset]);
 
+    // Subscribe directly to the Redux store instead of useSelector(getMessages).
+    // This decouples Tree rendering from message frequency: the component only
+    // re-renders (via setTree) when new topics are discovered, not on every message.
     useEffect(() => {
-        const newMsgs = messages.slice(processedRef.current);
-        if (newMsgs.length === 0) return;
+        return store.subscribe(() => {
+            const messages = getMessages((store as any).getState());
+            const newMsgs = messages.slice(processedRef.current);
+            if (newMsgs.length === 0) return;
+            processedRef.current = messages.length;
 
-        newMsgs.forEach((msg: core.MQTTMessage) => {
-            const {topic} = msg;
-            const splitedTopic = topic.split(constants.topicSeparator);
-            let lastNode: NodeType = treeRef.current;
+            let treeChanged = false;
+            const newLastMessages: Record<string, core.MQTTMessage> = {};
 
-            splitedTopic.forEach((subTopic: string, i: number) => {
-                const lastNodeTopic = lastNode.options?.nodeID ?? '';
-                const nodeID = `${lastNodeTopic}${lastNodeTopic === '' ? '' : constants.topicSeparator}${subTopic}`;
-                let node: NodeType = utils.createNode(nodeID, subTopic, [], {nodeID});
+            newMsgs.forEach((msg: core.MQTTMessage) => {
+                const {topic} = msg;
+                newLastMessages[topic] = msg;
 
-                const inTreeNode = lastNode.subnodes.find((n: NodeType) => n.id === nodeID);
-                if (inTreeNode !== undefined) {
-                    node = inTreeNode;
-                } else {
-                    if (!lastNode.subnodes.in(node, 'id')) {
+                if (knownLeafsRef.current.has(topic)) return; // known topic — skip tree walk
+                knownLeafsRef.current.add(topic);
+                treeChanged = true;
+
+                const parts = topic.split(constants.topicSeparator);
+                let lastNode = treeRef.current;
+                let nodeID = '';
+
+                parts.forEach((subTopic: string, i: number) => {
+                    nodeID = nodeID === '' ? subTopic : `${nodeID}${constants.topicSeparator}${subTopic}`;
+
+                    const existing = nodeMapRef.current.get(nodeID);
+                    const node: NodeType = existing ?? utils.createNode(nodeID, subTopic, [], {nodeID});
+                    if (!existing) {
                         lastNode.subnodes.push(node);
+                        nodeMapRef.current.set(nodeID, node);
                     }
-                }
 
-                if (splitedTopic.length - 1 === i) { // Leaf
-                    dispatch(setLastMessages({[topic]: msg}));
-                    if (!node.label.includes(constants.emojiFile)) node.label = `${node.label} ${constants.emojiFile}`;
-                } else { // Parent
-                    accParentsRef.current.push(node.id);
-                }
+                    if (i === parts.length - 1) { // leaf
+                        if (!node.label.includes(constants.emojiFile)) {
+                            node.label = `${node.label} ${constants.emojiFile}`;
+                        }
+                    } else { // parent
+                        accParentsRef.current.add(nodeID);
+                    }
 
-                lastNode = node;
+                    lastNode = node;
+                });
             });
+
+            dispatch(setLastMessages(newLastMessages));
+
+            if (treeChanged) {
+                setTree({...treeRef.current, subnodes: [...treeRef.current.subnodes]});
+                dispatch(setParentNodes([...accParentsRef.current]));
+            }
         });
+    }, []);
 
-        processedRef.current = messages.length;
-        setTree({...treeRef.current, subnodes: [...treeRef.current.subnodes]});
-        dispatch(setParentNodes([...accParentsRef.current]));
-    }, [messages]);
-
-    // TODO @@@ Node toggle handler rebind to work with the open handler (should be fixed one day)
     const goToggle = (_event: React.SyntheticEvent, nodeIds: string[]) => {
         dispatch(setOpenedNodes(nodeIds));
     };
@@ -108,7 +130,7 @@ export const Tree: React.FC = () => {
                     expanded={openedNodes}
                     onNodeToggle={goToggle}
                 >
-                    {(tree.subnodes.length > 0) && (<TreeItemRender key="pouet" node={tree}/>)}
+                    {(tree.subnodes.length > 0) && (<TreeItemRender key="root" node={tree}/>)}
                 </TreeView>
             </Grid>
         </Grid>

--- a/simulator/src/index.ts
+++ b/simulator/src/index.ts
@@ -64,42 +64,47 @@ function rawPublisher(client: MqttClient, topic: string, intervalMs: number, gen
 }
 
 // ── Sparkplug B publisher ─────────────────────────────────────────────────────
-type SpbMetric = {name: string; type: string; value: unknown};
-const rJson = (): string => {
-    const keys = ['temp','pressure','humidity','rpm','voltage','current','power','flow','torque','vibration'];
-    const out: Record<string, unknown> = {ts: Date.now(), seq: ri(0, 999999), ok: rb()};
-    for (let i = 0; i < ri(2, 6); i++) out[keys[ri(0, keys.length - 1)]] = rf();
-    return JSON.stringify(out);
-};
+// Fixed metric catalogue: each entry has a stable alias so NBIRTH declares name+alias
+// and NDATA/DDATA sends alias-only — exercising the alias registry in the backend.
+type SpbMetricDef = {name: string; type: string; alias: number; generate: () => unknown};
 
-const SPB_GENERATORS: Array<() => SpbMetric> = [
-    () => ({name: 'Temperature', type: 'Float',   value: rf(-40, 150)}),
-    () => ({name: 'Pressure',    type: 'Int32',   value: ri(0, 10000)}),
-    () => ({name: 'Active',      type: 'Boolean', value: rb()}),
-    () => ({name: 'JSONPayload', type: 'String',  value: rJson()}),
-    () => ({name: 'Voltage',     type: 'Double',  value: rf(0, 480)}),
-    () => ({name: 'Current',     type: 'Float',   value: rf(0, 100)}),
-    () => ({name: 'ErrorCode',   type: 'Int32',   value: ri(0, 255)}),
-    () => ({name: 'Label',       type: 'String',  value: `unit_${ri(1000, 9999)}`}),
-    () => ({name: 'Enabled',     type: 'Boolean', value: rb()}),
-    () => ({name: 'RPM',         type: 'Float',   value: rf(0, 3600)}),
-    () => ({name: 'FlowRate',    type: 'Double',  value: rf(0, 500)}),
-    () => ({name: 'Counter',     type: 'Int32',   value: ri(0, 2147483647)}),
+const SPB_METRIC_DEFS: SpbMetricDef[] = [
+    {name: 'Temperature', type: 'Float',   alias: 1,  generate: () => rf(-40, 150)},
+    {name: 'Pressure',    type: 'Int32',   alias: 2,  generate: () => ri(0, 10000)},
+    {name: 'Active',      type: 'Boolean', alias: 3,  generate: () => rb()},
+    {name: 'Voltage',     type: 'Double',  alias: 4,  generate: () => rf(0, 480)},
+    {name: 'Current',     type: 'Float',   alias: 5,  generate: () => rf(0, 100)},
+    {name: 'ErrorCode',   type: 'Int32',   alias: 6,  generate: () => ri(0, 255)},
+    {name: 'RPM',         type: 'Float',   alias: 7,  generate: () => rf(0, 3600)},
+    {name: 'FlowRate',    type: 'Double',  alias: 8,  generate: () => rf(0, 500)},
+    {name: 'Counter',     type: 'Int32',   alias: 9,  generate: () => ri(0, 2147483647)},
+    {name: 'Enabled',     type: 'Boolean', alias: 10, generate: () => rb()},
+    {name: 'Label',       type: 'String',  alias: 11, generate: () => `unit_${ri(1000, 9999)}`},
 ];
 
 let globalSeq = 0;
-function spbPayload(metricsCount: number): Buffer {
-    const metrics = Array.from({length: metricsCount}, (_, i) => SPB_GENERATORS[i % SPB_GENERATORS.length]());
+
+// Birth: full name + alias + value (defines the alias mapping)
+function spbBirthPayload(defs: SpbMetricDef[]): Buffer {
+    const metrics = defs.map(d => ({name: d.name, alias: d.alias, type: d.type, value: d.generate()}));
+    const payload: UPayload = {timestamp: Date.now(), seq: globalSeq++ % 256, metrics: metrics as any};
+    return Buffer.from(encodePayload(payload));
+}
+
+// Data: alias + value only — name intentionally omitted to test registry resolution
+function spbDataPayload(defs: SpbMetricDef[]): Buffer {
+    const metrics = defs.map(d => ({alias: d.alias, type: d.type, value: d.generate()}));
     const payload: UPayload = {timestamp: Date.now(), seq: globalSeq++ % 256, metrics: metrics as any};
     return Buffer.from(encodePayload(payload));
 }
 
 function spbPublisher(client: MqttClient, birthTopic: string, dataTopic: string, intervalMs: number, metricsCount: number): void {
     topicCount++;
-    client.publish(birthTopic, spbPayload(metricsCount));
+    const defs = SPB_METRIC_DEFS.slice(0, Math.min(metricsCount, SPB_METRIC_DEFS.length));
+    client.publish(birthTopic, spbBirthPayload(defs));
     totalPublished++;
     const tick = () => {
-        client.publish(dataTopic, spbPayload(metricsCount));
+        client.publish(dataTopic, spbDataPayload(defs));
         totalPublished++;
         const jitter = (Math.random() - 0.5) * intervalMs * 0.4;
         setTimeout(tick, Math.max(20, intervalMs + jitter));

--- a/simulator/src/index.ts
+++ b/simulator/src/index.ts
@@ -7,6 +7,7 @@
  * terms of the GNU GENERAL PUBLIC LICENSE which is available at
  *    https://github.com/Ambre-io/sparkplugui
  */
+import {gzipSync} from 'zlib';
 import {connectAsync, MqttClient} from 'mqtt';
 import {encodePayload, UPayload} from 'sparkplug-payload/lib/sparkplugbpayload';
 
@@ -82,34 +83,50 @@ const SPB_METRIC_DEFS: SpbMetricDef[] = [
     {name: 'Label',       type: 'String',  alias: 11, generate: () => `unit_${ri(1000, 9999)}`},
 ];
 
+const gzip = (buf: Buffer): Buffer => gzipSync(new Uint8Array(buf)) as Buffer;
+
 let globalSeq = 0;
 
 // Birth: full name + alias + value (defines the alias mapping)
-function spbBirthPayload(defs: SpbMetricDef[]): Buffer {
+function spbBirthPayload(defs: SpbMetricDef[], compress = false): Buffer {
     const metrics = defs.map(d => ({name: d.name, alias: d.alias, type: d.type, value: d.generate()}));
     const payload: UPayload = {timestamp: Date.now(), seq: globalSeq++ % 256, metrics: metrics as any};
-    return Buffer.from(encodePayload(payload));
+    const buf = Buffer.from(encodePayload(payload));
+    return compress ? gzip(buf) : buf;
 }
 
 // Data: alias + value only — name intentionally omitted to test registry resolution
-function spbDataPayload(defs: SpbMetricDef[]): Buffer {
+function spbDataPayload(defs: SpbMetricDef[], compress = false): Buffer {
     const metrics = defs.map(d => ({alias: d.alias, type: d.type, value: d.generate()}));
     const payload: UPayload = {timestamp: Date.now(), seq: globalSeq++ % 256, metrics: metrics as any};
-    return Buffer.from(encodePayload(payload));
+    const buf = Buffer.from(encodePayload(payload));
+    return compress ? gzip(buf) : buf;
 }
 
-function spbPublisher(client: MqttClient, birthTopic: string, dataTopic: string, intervalMs: number, metricsCount: number): void {
+function spbPublisher(client: MqttClient, birthTopic: string, dataTopic: string, intervalMs: number, metricsCount: number, compress = false): void {
     topicCount++;
     const defs = SPB_METRIC_DEFS.slice(0, Math.min(metricsCount, SPB_METRIC_DEFS.length));
-    client.publish(birthTopic, spbBirthPayload(defs));
+    client.publish(birthTopic, spbBirthPayload(defs, compress));
     totalPublished++;
     const tick = () => {
-        client.publish(dataTopic, spbDataPayload(defs));
+        client.publish(dataTopic, spbDataPayload(defs, compress));
         totalPublished++;
         const jitter = (Math.random() - 0.5) * intervalMs * 0.4;
         setTimeout(tick, Math.max(20, intervalMs + jitter));
     };
     setTimeout(tick, ri(0, intervalMs));
+}
+
+// Dedicated GZIP test node — publishes compressed Sparkplug B on spBv1.0/test/
+function spawnGzipTest(client: MqttClient): void {
+    spbPublisher(client,
+        `${TOPIC_BASE}/test/NBIRTH/gzip_node`,
+        `${TOPIC_BASE}/test/NDATA/gzip_node`,
+        500, SPB_METRIC_DEFS.length, true);
+    spbPublisher(client,
+        `${TOPIC_BASE}/test/DBIRTH/gzip_node/gzip_device`,
+        `${TOPIC_BASE}/test/DDATA/gzip_node/gzip_device`,
+        500, SPB_METRIC_DEFS.length, true);
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -498,6 +515,7 @@ function spawnMisc(client: MqttClient): void {
     spawnAlerts(client);
     spawnFiles(client);
     spawnMisc(client);
+    spawnGzipTest(client);
 
     console.log(`\n${topicCount} publishers running across all topic families.`);
     console.log(`Press Ctrl+C to stop.\n`);


### PR DESCRIPTION
## What's inside

- **GZIP / DEFLATE decompression**: payloads compressed by Ignition (or any broker) are now automatically decompressed before parsing, using magic-byte detection
- **Sparkplug alias registry**: birth messages (NBIRTH/DBIRTH) are captured and their `alias → name` mappings stored; subsequent data messages (NDATA/DDATA) resolve aliases back to real metric names instead of showing `alias:42`
- **Simulator updated**: birth messages now include both name + alias, data messages send alias-only, to properly exercise the registry end-to-end; a dedicated `spBv1.0/test/gzip_*` node publishes compressed payloads for testing
- **Tree performance**: decoupled from the message flow via `store.subscribe`; the tree only re-renders when new topics appear, not on every incoming message; node lookup is now O(1) via a flat Map
- **UX**: topic field and expand-all button are disabled while connected to avoid accidental resets or laggy full-tree renders; tree also resets on host change (not just topic change)